### PR TITLE
fix protoc output parsing bug

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -60,7 +60,7 @@ func parseFile(filename string, includeSourceInfo bool, includeImports bool, pat
 	args = append(args, filename)
 	cmd := exec.Command("protoc", args...)
 	cmd.Env = []string{}
-	data, err := cmd.CombinedOutput()
+	data, err := cmd.Output()
 	if err != nil {
 		return nil, &errCmd{data, err}
 	}


### PR DESCRIPTION
The parseFile function execute a protoc process to retrieve the message descriptor from a file and then parse from the output of the process, but it makes use of the CombinedOutput method of the Cmd struct, which combined both the stdout and stderr of the process, leading to imparseable string when the protoc process emits warnings on stderr.
I just replaced the call to CombinedOutput but a call to Output, which only returns stdout.
